### PR TITLE
Trim docker container down to 473MB

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,6 @@
 .idea
 .DS_Store
 dockerfiles
+Vagrantfile
+sample_jsons
+log/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,15 +17,15 @@ RUN echo "gem: --no-rdoc --no-ri" >> ~/.gemrc
 RUN apk --no-cache --update add build-base \
     libc-dev libxml2-dev imagemagick6 imagemagick6-dev pkgconf nodejs postgresql-dev tzdata
 
-RUN gem install bundler && bundle install --without development test -j4 --retry 3
+RUN gem install bundler && bundle install --deployment --without development test -j4 --retry 3
 
 COPY . .
 
 # precompile is only necessary for production builds
 RUN sh -c "RAILS_ENV=$RAILS_ENV SECRET_KEY_BASE=xxx bundle exec rake assets:precompile"
 
-RUN rm -rf tmp/cache spec /usr/local/bundle/cache && find /usr/local/bundle/gems/ -name "*.c" -delete && \
-    find /usr/local/bundle/gems/ -name "*.o"
+RUN rm -rf tmp/cache spec vendor/bundle/ruby/*/cache && find vendor/bundle/ruby/*/gems/ -name "*.c" -delete && \
+    find vendor/bundle/ruby/*/gems/ -name "*.o" -delete
 
 # The container above is only used for building. Once the source code is built we copy
 # the required artifacts out of the build above and put them in a clean container.
@@ -38,10 +38,12 @@ RUN mkdir -p $RAILS_ROOT
 
 WORKDIR $RAILS_ROOT
 
-COPY --from=Builder /usr/local/bundle/ /usr/local/bundle/
 COPY --from=Builder $RAILS_ROOT $RAILS_ROOT
 
-RUN apk --no-cache --update add nodejs imagemagick6 postgresql-dev tzdata && gem install bundler
+# It is necessary to re-run bundle install since the /usr/local/bundle/config file is missing on the 2nd container.
+# By running bundle install that file is created and bundler begins working correctly.
+RUN apk --no-cache --update add nodejs imagemagick6 postgresql-dev tzdata && gem install bundler && \
+    bundle install --deployment --without development test
 
 EXPOSE 3000
 

--- a/Gemfile
+++ b/Gemfile
@@ -50,15 +50,13 @@ gem 'nokogiri-happymapper'
 gem 'nokogiri'
 gem 'thor'
 gem 'json'
-gem 'pry'
-gem 'pry-nav'
 
 gem 'inspec_tools', '~>1.3.0'
 gem 'roo'
 
 group :development, :test do
-  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'pry'
+  gem 'pry-nav'
   gem 'rspec-rails', '~> 3.6'
   gem 'rubocop-rspec'
   gem 'factory_bot_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,7 +73,6 @@ GEM
       msgpack (~> 1.0)
     brakeman (4.5.1)
     builder (3.2.3)
-    byebug (11.0.1)
     cancancan (2.3.0)
     capybara (3.18.0)
       addressable
@@ -547,7 +546,6 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.1.0)
   brakeman
-  byebug
   cancancan (~> 2.0)
   capybara (>= 2.15)
   carrierwave


### PR DESCRIPTION
This moves over to using vendor/bundle to store gems, dockerignores more files that are not necessary for the docker container to work, and moves some gems out of production that shouldn't be there.